### PR TITLE
Add NULLS FIRST/LAST to ORDER BY, Fixes #12

### DIFF
--- a/R/parse_clauses.R
+++ b/R/parse_clauses.R
@@ -69,11 +69,11 @@ parse_having <- function(exprs, tidyverse, secure = TRUE) {
 parse_order_by <- function(exprs, tidyverse, secure = TRUE) {
   if (is.null(exprs)) return(NULL)
 
-  if (any(grepl("^(asc|desc)", tolower(exprs)))) {
+  if (any(grepl("^(asc|desc)", exprs, ignore.case = TRUE))) {
     stop("Invalid use of ASC or DESC in the ORDER BY clause", call. = FALSE)
   }
 
-  if (any(grepl("^(asc |desc )?nulls (first|last)", tolower(exprs)))) {
+  if (any(grepl("^(asc |desc )?nulls (first|last)", exprs, ignore.case = TRUE))) {
     stop("Invalid use of NULLS FIRST or NULLS LAST in the ORDER BY clause", call. = FALSE)
   }
 

--- a/R/parse_clauses.R
+++ b/R/parse_clauses.R
@@ -82,17 +82,15 @@ parse_order_by <- function(exprs, tidyverse, secure = TRUE) {
     stop("Positional column references in the ORDER BY clause are not supported", call. = FALSE)
   }
 
-  if (tidyverse) {
-    for (i in which(descending_cols)) {
+  for (i in which(descending_cols)) {
+    if (tidyverse) {
       exprs[[i]] <- paste0("dplyr::desc(", exprs[[i]], ")")
+    } else {
+      exprs[[i]] <- paste0("-xtfrm(", exprs[[i]], ")")
     }
   }
 
   exprs <- sapply(exprs, parse_expression, tidyverse = tidyverse, secure = secure, USE.NAMES = FALSE)
-
-  if (!tidyverse) {
-    attr(exprs, "decreasing") <- descending_cols
-  }
 
   exprs
 }

--- a/R/parse_clauses.R
+++ b/R/parse_clauses.R
@@ -74,8 +74,11 @@ parse_order_by <- function(exprs, tidyverse, secure = TRUE) {
   }
 
   descending_cols <- order_is_desc(exprs)
+  nulls_first_cols <- order_is_nulls_first(exprs)
+  nulls_last_cols <- order_is_nulls_last(exprs)
 
   exprs <- remove_asc_desc(exprs)
+  exprs <- remove_nulls_first_last(exprs)
 
   suppressWarnings(int_positions <- as.integer(exprs))
   if (any(!is.na(int_positions))) {
@@ -90,10 +93,21 @@ parse_order_by <- function(exprs, tidyverse, secure = TRUE) {
     }
   }
 
+  exprs <- as.list(exprs)
+  for (i in which(nulls_first_cols)) {
+    exprs[[i]] <- c(paste0("!is.na(", exprs[[i]], ")"), exprs[[i]])
+  }
+
+  for (i in which(nulls_last_cols)) {
+    exprs[[i]] <- c(paste0("is.na(", exprs[[i]], ")"), exprs[[i]])
+  }
+  exprs <- unlist(exprs, recursive = FALSE, use.names = FALSE)
+
   exprs <- sapply(exprs, parse_expression, tidyverse = tidyverse, secure = secure, USE.NAMES = FALSE)
 
   exprs
 }
+
 
 parse_limit <- function(exprs) {
   if (is.null(exprs)) return(NULL)
@@ -110,9 +124,21 @@ parse_limit <- function(exprs) {
 }
 
 order_is_desc <- function(exprs) {
-  grepl("\\bDESC$", exprs, ignore.case = TRUE)
+  grepl("\\bDESC\\b", exprs, ignore.case = TRUE)
+}
+
+order_is_nulls_first <- function(exprs) {
+  grepl("\\bNULLS FIRST\\b", exprs, ignore.case = TRUE)
+}
+
+order_is_nulls_last <- function(exprs) {
+  grepl("\\bNULLS LAST\\b", exprs, ignore.case = TRUE)
 }
 
 remove_asc_desc <- function(exprs) {
-  gsub("\\b ?(A|DE)SC$", "", exprs, ignore.case = TRUE)
+  gsub("\\b ?(A|DE)SC\\b", "", exprs, ignore.case = TRUE)
+}
+
+remove_nulls_first_last <- function(exprs) {
+  gsub("\\b NULLS (FIRST|LAST)\\b", "", exprs, ignore.case = TRUE)
 }

--- a/R/parse_clauses.R
+++ b/R/parse_clauses.R
@@ -69,8 +69,12 @@ parse_having <- function(exprs, tidyverse, secure = TRUE) {
 parse_order_by <- function(exprs, tidyverse, secure = TRUE) {
   if (is.null(exprs)) return(NULL)
 
-  if (any(tolower(exprs) %in% c("asc", "desc"))) {
+  if (any(grepl("^(asc|desc)", tolower(exprs)))) {
     stop("Invalid use of ASC or DESC in the ORDER BY clause", call. = FALSE)
+  }
+
+  if (any(grepl("^(asc |desc )?nulls (first|last)", tolower(exprs)))) {
+    stop("Invalid use of NULLS FIRST or NULLS LAST in the ORDER BY clause", call. = FALSE)
   }
 
   descending_cols <- order_is_desc(exprs)

--- a/R/secure.R
+++ b/R/secure.R
@@ -56,7 +56,7 @@ allowed_funs_generic <- c(
   "!=",  "<", "<=", "=", "==", ">", ">=",
   "cast", "count_star", "is.na",
   "as.logical", "%in%", "%nin%",  "ifelse",
-  "(", "c", "between",
+  "(", "c", "between", "xtfrm",
   sql_data_types_with_args,
   unname(unlist(translations_operators_binary_symbolic)),
   unname(unlist(translations_operators_binary_word)),

--- a/tests/testthat/test-parse_query.R
+++ b/tests/testthat/test-parse_query.R
@@ -51,8 +51,7 @@ test_that("parse_query(tidy = FALSE) works on 'flights' example query", {
       where = list(quote((distance >= 200 & distance <= 300) &
       !is.na(air_time))), group_by = list(quote(origin), quote(dest)),
       having = list(quote(num_flts > 3000)), order_by = structure(list(
-      quote(num_flts), quote(avg_delay)), decreasing = c(TRUE,
-      TRUE), aggregate = c(FALSE, FALSE)), limit = list(100L)), aggregate = TRUE)
+      quote(-xtfrm(num_flts)), quote(-xtfrm(avg_delay))), aggregate = c(FALSE, FALSE)), limit = list(100L)), aggregate = TRUE)
   )
 })
 
@@ -320,6 +319,25 @@ test_that("parse_query() works on SELECT ALL example query", {
   )
 })
 
+test_that("parse_query works with NULLS FIRST in ORDER BY", {
+  expect_equal(
+    parse_query("SELECT x FROM df ORDER BY x NULLS FIRST"),
+    list(select = list(quote(x)),
+         from = list(quote(df)),
+         order_by = list(quote(!is.na(x)), quote(x)))
+  )
+})
+
+test_that("parse_query works with NULLS LAST in ORDER BY", {
+  expect_equal(
+    parse_query("SELECT x FROM df ORDER BY x NULLS LAST"),
+    list(select = list(quote(x)),
+         from = list(quote(df)),
+         order_by = list(quote(is.na(x)), quote(x)))
+  )
+})
+
+
 test_that("parse_query() stops on positional column references in ORDER BY clause", {
   expect_error(
     parse_query("SELECT x, y, z FROM t ORDER BY 1 DESC, 2"),
@@ -407,6 +425,20 @@ test_that("parse_query() stops when invalid use of ASC in ORDER BY clause", {
 test_that("parse_query() stops when invalid use of DESC in ORDER BY clause", {
   expect_error(
     parse_query("SELECT x FROM y ORDER BY x, DESC"),
+    "^Invalid"
+  )
+})
+
+test_that("parse_query() stops when invalid use of NULLS FIRST in ORDER BY clause", {
+  expect_error(
+    parse_query("SELECT x FROM y ORDER BY x, NULLS FIRST"),
+    "^Invalid"
+  )
+})
+
+test_that("parse_query() stops when invalid use of NULLS LAST in ORDER BY clause", {
+  expect_error(
+    parse_query("SELECT x FROM y ORDER BY x, NULLS LAST"),
     "^Invalid"
   )
 })
@@ -519,8 +551,7 @@ test_that("parse_query() removes table name prefixes in single-table queries", {
       parse_query(query)
     },
     list(select = list(quote(year), quote(month), quote(day)), from = list(quote(flights)),
-      where = list(quote(arr_delay <= 0)), order_by = structure(list(quote(carrier)),
-      decreasing = FALSE))
+      where = list(quote(arr_delay <= 0)), order_by = structure(list(quote(carrier))))
   )
 })
 
@@ -534,8 +565,7 @@ test_that("parse_query() removes table alias prefixes in single-table queries", 
       parse_query(query)
     },
     list(select = list(quote(year), quote(month), quote(day)), from = list(f = quote(flights)),
-      where = list(quote(arr_delay <= 0)), order_by = structure(list(quote(carrier)),
-      decreasing = FALSE))
+      where = list(quote(arr_delay <= 0)), order_by = structure(list(quote(carrier))))
   )
 })
 


### PR DESCRIPTION
This allows NULLS FIRST and NULLS LAST in each ORDER BY expression. It works by prepending `is.na(x)` before `x` in the `order_by` list. This had two knock-on consequences:

1. I changed `exprs` to a list so I could replace a single element with 2 elements
2. I removed the `descending` attribute and provided a base R alternative to `dplyr::desc` instead