### PR TITLE
Add several conversion, string, and logic functions (mostly from MS SQL Server)

### DIFF
--- a/R/replace.R
+++ b/R/replace.R
@@ -49,7 +49,7 @@ replace_special_functions <- function(expr_quotes_masked) {
 
 replace_special_keywords <- function(expr_quotes_masked) {
 
-  special_keywords <- c("CAST", "TRY_CAST", "BETWEEN", "CASE")
+  special_keywords <- c("CAST", "TRY_CAST", "TRY_CONVERT", "BETWEEN", "CASE")
 
   if (!grepl(paste0("\\b(", paste(special_keywords, collapse = "|"), ")\\b"), expr_quotes_masked, ignore.case = TRUE)) {
     return(expr_quotes_masked)
@@ -85,6 +85,13 @@ replace_special_keywords <- function(expr_quotes_masked) {
       expr_quotes_masked <- paste(repl_strings, collapse = "")
       iter <- iter + 1L # each iteration changes "as" to "," which shortens the string on the left by 1
     }
+  }
+
+  # replace TRY_CONVERT
+  if (grepl(paste0("\\bTRY_CONVERT\\b"), expr_quotes_masked, ignore.case = TRUE)) {
+    # TRY_CONVERT converts to NULL when attempt fails, just like R's `as.*` functions
+    # So, we can handle it the same as CONVERT
+    expr_quotes_masked <- gsub("(\\b)TRY_CONVERT(\\b)", "\\1CONVERT\\2", expr_quotes_masked, ignore.case = TRUE)
   }
 
   # replace NOT BETWEEN and BETWEEN

--- a/R/replace.R
+++ b/R/replace.R
@@ -49,7 +49,7 @@ replace_special_functions <- function(expr_quotes_masked) {
 
 replace_special_keywords <- function(expr_quotes_masked) {
 
-  special_keywords <- c("CAST", "BETWEEN", "CASE")
+  special_keywords <- c("CAST", "TRY_CAST", "BETWEEN", "CASE")
 
   if (!grepl(paste0("\\b(", paste(special_keywords, collapse = "|"), ")\\b"), expr_quotes_masked, ignore.case = TRUE)) {
     return(expr_quotes_masked)
@@ -58,6 +58,13 @@ replace_special_keywords <- function(expr_quotes_masked) {
   original_encoding <- Encoding(expr_quotes_masked)
   Encoding(expr_quotes_masked) <- "bytes"
   nchar_bytes <- nchar(expr_quotes_masked, type = "bytes")
+
+  # replace TRY_CAST
+  if (grepl(paste0("\\bTRY_CAST\\b"), expr_quotes_masked, ignore.case = TRUE)) {
+    # TRY_CAST converts to NULL when attempt fails, just like R's `as.*` functions
+    # So, we can handle it the same as CAST
+    expr_quotes_masked <- gsub("(\\b)TRY_CAST(\\b)", "\\1CAST\\2", expr_quotes_masked, ignore.case = TRUE)
+  }
 
   # replace CAST
   if (grepl(paste0("\\bCAST\\b"), expr_quotes_masked, ignore.case = TRUE)) {

--- a/R/translations.R
+++ b/R/translations.R
@@ -405,7 +405,7 @@ translations_indirect_base <- list(
     eval(substitute(quote(paste(..., sep = sep))))
   },
   nullif = function(x, y) {
-    eval(substitute(quote(ifelse(is.na(x), x, y))))
+    eval(substitute(quote(ifelse(x==y, NA, x))))
   },
   lpad = function(str, len, pad) {
     if (!is_constant(eval(substitute(quote(len)))) ||

--- a/R/translations.R
+++ b/R/translations.R
@@ -504,14 +504,14 @@ translations_indirect_base <- list(
     }
   },
   charindex = function(string, substring) {
-    warning("Using CHARINDEX with non-ASCII characters may return incorrect results due to multiple ways to represent the same character")
+    warning("Using CHARINDEX with non-ASCII characters may return incorrect results due to multiple ways to represent the same character", call. = FALSE)
     eval(substitute(quote(regexpr(substring, string, fixed = TRUE)[1])))
   },
   reverse = function(x) {
     eval(substitute(quote(sapply(lapply(strsplit(x, ""), rev), paste, collapse = ""))))
   },
   replace = function(string, substring, replacement) {
-    warning("Using REPLACE with non-ASCII characters may return incorrect results due to multiple ways to represent the same character")
+    warning("Using REPLACE with non-ASCII characters may return incorrect results due to multiple ways to represent the same character", call. = FALSE)
     eval(substitute(quote(gsub(substring, replacement, string, fixed = TRUE))))
   }
 )

--- a/R/translations.R
+++ b/R/translations.R
@@ -313,7 +313,21 @@ translations_indirect_generic <- list(
     eval(substitute(quote(ifelse(is.na(x), y, x))))
   },
   isnull = function(x, y) {
-    eval(substitute(quote(ifelse(is.na(x), y, x))))
+    if (!nargs() %in% c(1,2)) {
+      stop("Function ISNULL() requires one or two parameters", call. = FALSE)
+    }
+
+    # MySQL/Hive check for NULL-ness
+    if (nargs() == 1) {
+      expr <- eval(substitute(quote(is.na(x))))
+    }
+
+    # SQL Server replace NULL (similar to IFNULL, NVL, COALESCE)
+    if (nargs() == 2) {
+      expr <- eval(substitute(quote(ifelse(is.na(x), y, x))))
+    }
+
+    expr
   },
   nvl = function(x, y) {
     eval(substitute(quote(ifelse(is.na(x), y, x))))

--- a/R/translations.R
+++ b/R/translations.R
@@ -614,6 +614,29 @@ translations_indirect_tidyverse <- list(
     func <- str2lang(func_name)
     eval(substitute(quote(func(x))))
   },
+  try_cast = function(x, y = NULL) {
+    y <- eval(substitute(quote(y)))
+    if (is.call(y) && !is_constant(y)) {
+      stop("Invalid data type in TRY_CAST", call. = FALSE)
+    }
+    if (is.null(y)) stop("Unspecified data type in TRY_CAST", call. = FALSE)
+    if (is.call(y)) {
+      data_type <- data_type_translations_for_tidyverse[[tolower(deparse(y[[1]]))]]
+    } else {
+      data_type <- data_type_translations_for_tidyverse[[tolower(deparse(y))]]
+    }
+    if (is.null(data_type)) stop("Unrecognized data type in TRY_CAST", call. = FALSE)
+    func_name <- attr(data_type, "function")
+    if (is.null(func_name)) {
+      func_name <- paste0("as.", data_type)
+    }
+    pkg_name <- attr(data_type, "package")
+    if (!is.null(pkg_name)) {
+      func_name <- paste(pkg_name, func_name, sep = "::")
+    }
+    func <- str2lang(func_name)
+    eval(substitute(quote(suppressWarnings(func(x)))))
+  },
   convert = function(y = NULL, x) {
     y <- eval(substitute(quote(y)))
     if (is.call(y) && !is_constant(y)) {
@@ -636,6 +659,29 @@ translations_indirect_tidyverse <- list(
     }
     func <- str2lang(func_name)
     eval(substitute(quote(func(x))))
+  },
+  try_convert = function(y = NULL, x) {
+    y <- eval(substitute(quote(y)))
+    if (is.call(y) && !is_constant(y)) {
+      stop("Invalid data type in TRY_CONVERT", call. = FALSE)
+    }
+    if (is.null(y)) stop("Unspecified data type in TRY_CONVERT", call. = FALSE)
+    if (is.call(y)) {
+      data_type <- data_type_translations_for_tidyverse[[tolower(deparse(y[[1]]))]]
+    } else {
+      data_type <- data_type_translations_for_tidyverse[[tolower(deparse(y))]]
+    }
+    if (is.null(data_type)) stop("Unrecognized data type in TRY_CONVERT", call. = FALSE)
+    func_name <- attr(data_type, "function")
+    if (is.null(func_name)) {
+      func_name <- paste0("as.", data_type)
+    }
+    pkg_name <- attr(data_type, "package")
+    if (!is.null(pkg_name)) {
+      func_name <- paste(pkg_name, func_name, sep = "::")
+    }
+    func <- str2lang(func_name)
+    eval(substitute(quote(suppressWarnings(func(x)))))
   },
   casewhen = function(... , otherwise) {
     dots <- eval(substitute(alist(...)))

--- a/R/translations.R
+++ b/R/translations.R
@@ -411,7 +411,7 @@ translations_indirect_base <- list(
     eval(substitute(quote(paste(..., sep = sep))))
   },
   nullif = function(x, y) {
-    eval(substitute(quote(ifelse(is.na(x), x, y))))
+    eval(substitute(quote(ifelse(x==y, NA, x))))
   },
   lpad = function(str, len, pad) {
     if (!is_constant(eval(substitute(quote(len)))) ||

--- a/R/translations.R
+++ b/R/translations.R
@@ -732,6 +732,12 @@ translations_indirect_base_agg <- list(
       stop("Function GROUP_CONCAT() requires one or two parameters", call. = FALSE)
     }
     eval(substitute(quote(paste0(x, collapse = sep))))
+  },
+  string_agg = function(x, sep) {
+    if (!nargs() == 2) {
+      stop("Function STRING_AGG() requires two parameters", call. = FALSE)
+    }
+    eval(substitute(quote(paste0(x, collapse = sep))))
   }
 )
 
@@ -754,6 +760,13 @@ translations_indirect_tidyverse_agg <- list(
   group_concat = function(x, sep = ", ") {
     if (!nargs() %in% c(1,2)) {
       stop("Function GROUP_CONCAT() requires one or two parameters", call. = FALSE)
+    }
+    fun <- str2lang("stringr::str_flatten")
+    eval(substitute(quote(fun(x, collapse = sep))))
+  },
+  string_agg = function(x, sep) {
+    if (!nargs() == 2) {
+      stop("Function STRING_AGG() requires two parameters", call. = FALSE)
     }
     fun <- str2lang("stringr::str_flatten")
     eval(substitute(quote(fun(x, collapse = sep))))

--- a/R/translations.R
+++ b/R/translations.R
@@ -356,6 +356,29 @@ translations_indirect_base <- list(
     func <- str2lang(func_name)
     eval(substitute(quote(func(x))))
   },
+  try_cast = function(x, y = NULL) {
+    y <- eval(substitute(quote(y)))
+    if (is.call(y) && !is_constant(y)) {
+      stop("Invalid data type in TRY_CAST", call. = FALSE)
+    }
+    if (is.null(y)) stop("Unspecified data type in TRY_CAST", call. = FALSE)
+    if (is.call(y)) {
+      data_type <- data_type_translations_for_base[[tolower(deparse(y[[1]]))]]
+    } else {
+      data_type <- data_type_translations_for_base[[tolower(deparse(y))]]
+    }
+    if (is.null(data_type)) stop("Unrecognized data type in TRY_CAST", call. = FALSE)
+    func_name <- attr(data_type, "function")
+    if (is.null(func_name)) {
+      func_name <- paste0("as.", data_type)
+    }
+    pkg_name <- attr(data_type, "package")
+    if (!is.null(pkg_name)) {
+      func_name <- paste(pkg_name, func_name, sep = "::")
+    }
+    func <- str2lang(func_name)
+    eval(substitute(quote(suppressWarnings(func(x)))))
+  },
   convert = function(y = NULL, x) {
     y <- eval(substitute(quote(y)))
     if (is.call(y) && !is_constant(y)) {
@@ -378,6 +401,29 @@ translations_indirect_base <- list(
     }
     func <- str2lang(func_name)
     eval(substitute(quote(func(x))))
+  },
+  try_convert = function(y = NULL, x) {
+    y <- eval(substitute(quote(y)))
+    if (is.call(y) && !is_constant(y)) {
+      stop("Invalid data type in TRY_CONVERT", call. = FALSE)
+    }
+    if (is.null(y)) stop("Unspecified data type in TRY_CONVERT", call. = FALSE)
+    if (is.call(y)) {
+      data_type <- data_type_translations_for_base[[tolower(deparse(y[[1]]))]]
+    } else {
+      data_type <- data_type_translations_for_base[[tolower(deparse(y))]]
+    }
+    if (is.null(data_type)) stop("Unrecognized data type in TRY_CONVERT", call. = FALSE)
+    func_name <- attr(data_type, "function")
+    if (is.null(func_name)) {
+      func_name <- paste0("as.", data_type)
+    }
+    pkg_name <- attr(data_type, "package")
+    if (!is.null(pkg_name)) {
+      func_name <- paste(pkg_name, func_name, sep = "::")
+    }
+    func <- str2lang(func_name)
+    eval(substitute(quote(suppressWarnings(func(x)))))
   },
   casewhen = function(... , otherwise) {
     dots <- eval(substitute(alist(...)))

--- a/R/translations.R
+++ b/R/translations.R
@@ -346,6 +346,29 @@ translations_indirect_base <- list(
     func <- str2lang(func_name)
     eval(substitute(quote(func(x))))
   },
+  convert = function(y = NULL, x) {
+    y <- eval(substitute(quote(y)))
+    if (is.call(y) && !is_constant(y)) {
+      stop("Invalid data type in CONVERT", call. = FALSE)
+    }
+    if (is.null(y)) stop("Unspecified data type in CONVERT", call. = FALSE)
+    if (is.call(y)) {
+      data_type <- data_type_translations_for_base[[tolower(deparse(y[[1]]))]]
+    } else {
+      data_type <- data_type_translations_for_base[[tolower(deparse(y))]]
+    }
+    if (is.null(data_type)) stop("Unrecognized data type in CONVERT", call. = FALSE)
+    func_name <- attr(data_type, "function")
+    if (is.null(func_name)) {
+      func_name <- paste0("as.", data_type)
+    }
+    pkg_name <- attr(data_type, "package")
+    if (!is.null(pkg_name)) {
+      func_name <- paste(pkg_name, func_name, sep = "::")
+    }
+    func <- str2lang(func_name)
+    eval(substitute(quote(func(x))))
+  },
   casewhen = function(... , otherwise) {
     dots <- eval(substitute(alist(...)))
     otherwise <- eval(substitute(quote(otherwise)))
@@ -499,6 +522,29 @@ translations_indirect_tidyverse <- list(
       data_type <- data_type_translations_for_tidyverse[[tolower(deparse(y))]]
     }
     if (is.null(data_type)) stop("Unrecognized data type in CAST", call. = FALSE)
+    func_name <- attr(data_type, "function")
+    if (is.null(func_name)) {
+      func_name <- paste0("as.", data_type)
+    }
+    pkg_name <- attr(data_type, "package")
+    if (!is.null(pkg_name)) {
+      func_name <- paste(pkg_name, func_name, sep = "::")
+    }
+    func <- str2lang(func_name)
+    eval(substitute(quote(func(x))))
+  },
+  convert = function(y = NULL, x) {
+    y <- eval(substitute(quote(y)))
+    if (is.call(y) && !is_constant(y)) {
+      stop("Invalid data type in CONVERT", call. = FALSE)
+    }
+    if (is.null(y)) stop("Unspecified data type in CONVERT", call. = FALSE)
+    if (is.call(y)) {
+      data_type <- data_type_translations_for_tidyverse[[tolower(deparse(y[[1]]))]]
+    } else {
+      data_type <- data_type_translations_for_tidyverse[[tolower(deparse(y))]]
+    }
+    if (is.null(data_type)) stop("Unrecognized data type in CONVERT", call. = FALSE)
     func_name <- attr(data_type, "function")
     if (is.null(func_name)) {
       func_name <- paste0("as.", data_type)

--- a/R/translations.R
+++ b/R/translations.R
@@ -301,6 +301,12 @@ translations_indirect_generic <- list(
   },
   ifnull = function(x, y) {
     eval(substitute(quote(ifelse(is.na(x), y, x))))
+  },
+  isnull = function(x, y) {
+    eval(substitute(quote(ifelse(is.na(x), y, x))))
+  },
+  nvl = function(x, y) {
+    eval(substitute(quote(ifelse(is.na(x), y, x))))
   }
 )
 

--- a/tests/testthat/test-parse_query.R
+++ b/tests/testthat/test-parse_query.R
@@ -385,14 +385,28 @@ test_that("parse_query() stops when unvalid expression used in a SELECT DISTINCT
 test_that("parse_query() stops on incomplete CAST expression", {
   expect_error(
     parse_query("SELECT CAST(x) FROM y"),
-    "cast"
+    "CAST"
   )
 })
 
 test_that("parse_query() stops on malformed CAST expression", {
   expect_error(
     parse_query("SELECT CAST(x) AS y FROM z"),
-    "cast"
+    "CAST"
+  )
+})
+
+test_that("parse_query() stops on incomplete TRY_CAST expression", {
+  expect_error(
+    parse_query("SELECT TRY_CAST(x) FROM y"),
+    "TRY_CAST"
+  )
+})
+
+test_that("parse_query() stops on malformed TRY_CAST expression", {
+  expect_error(
+    parse_query("SELECT TRY_CAST(x) AS y FROM z"),
+    "TRY_CAST"
   )
 })
 

--- a/tests/testthat/test-parse_query.R
+++ b/tests/testthat/test-parse_query.R
@@ -356,8 +356,8 @@ test_that("parse_query(tidy = TRUE) works with ASC/DESC and NULLS FIRST/LAST in 
     ),
     list(select = list(quote(w), quote(x), quote(y), quote(z)), from = list(quote(df)),
       order_by = list(quote(!is.na(w)), quote(w), quote(!is.na(x)),
-      quote(dplyr::desc(x)), quote(is.na(y)), quote(y), quote(is.na(z)),
-      quote(dplyr::desc(z))))
+      str2lang("dplyr::desc(x)"), quote(is.na(y)), quote(y), quote(is.na(z)),
+      str2lang("dplyr::desc(z)")))
   )
 })
 


### PR DESCRIPTION
This is a loose collection of additions to the translations. There is one *fix* that I noticed while looking for missing function (`nullif`'s base R translation). Here's what is added:

1. Conversion functions from SQL Server (`TRY_CAST`, `CONVERT`, and `TRY_CONVERT`) to complement `CAST`
2. String functions (`STRING_AGG`, `REVERSE`, `REPLACE`, `CHARINDEX`, and `REPLICATE`)
3. Logic functions (`ISNULL`, `NVL`, `CHOOSE`)